### PR TITLE
Unbalanced tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -127,8 +127,8 @@ include 'includes/head.php';
 <div class="row">
 <jdoc:include type="modules" name="content-bottom" style="block" />	
 </div>
-<?php endif; ?>
 </div>
+<?php endif; ?>
 </div>
 <!-- Right -->
 <?php if($this->countModules('right')) : ?>


### PR DESCRIPTION
When no content-bottom modules exist the layout is incorrectly closed.