### PR TITLE
Overriden files are not processed when the main scss has been cached

### DIFF
--- a/vendor/phproberto/sass/src/FileCompiler.php
+++ b/vendor/phproberto/sass/src/FileCompiler.php
@@ -195,6 +195,18 @@ class FileCompiler
 
 		foreach ($dependencies as $file => $fileUpdateTime)
 		{
+			if (!file_exists($file))
+			{
+				return true;
+			}
+
+			$overridenFile = $this->getOverridenFile($file);
+
+			if ($overridenFile)
+			{
+				$file = $overridenFile;
+			}
+
 			$currentFileTime = filemtime($file);
 
 			if ($currentFileTime !== $fileUpdateTime || $currentFileTime > $destFileTime)
@@ -232,6 +244,31 @@ class FileCompiler
 		}
 
 		return $this->compiler;
+	}
+
+	/**
+	 * Check if a Sass file has an override.
+	 *
+	 * @param   string  $file  Path to the source file to search for overrides
+	 *
+	 * @return  string
+	 */
+	private function getOverridenFile($file)
+	{
+		if (!file_exists($file))
+		{
+			return null;
+		}
+
+		$overridenFileName = ltrim(basename($file), '_');
+		$overridenFile = dirname($file) . '/' . $overridenFileName;
+
+		if ($overridenFileName === basename($file) || !file_exists($overridenFile))
+		{
+			return null;
+		}
+
+		return $overridenFile;
 	}
 
 	/**


### PR DESCRIPTION
To override any scss file user has to duplicate the file and remove the underscore from its name. So for `_custom.scss` the overriden file would be `custom.scss` (without `_`).

This fixes an issue when the user creates an override after the main file has been cached. So if `_custom.scss` has been compiled and you don't change it but create an override the file is not properly recompiled/refreshed.

It also avoids warnings when a file has been removed after it has been used in a compilation. Let's say that you create a `custom.scss` file and then your remove it. That caused a php warning. Now it detects that a file has been removed and automatically recompiles the parent file.