### PR TITLE
De-hard-code language identifier

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if ($params->get('compile_sass', '0') === '1')
 }
 ?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<?php echo $this->language; ?>">
 <?php
  include 'includes/head.php'; ?>
 <body>


### PR DESCRIPTION
Currently the language identifier ist hard-coded to "en" in index.php.
In order to make the template compatible with non-English sites the code should be set by the system.